### PR TITLE
Fix missing

### DIFF
--- a/articles/cognitive-services/Custom-Speech-Service/CustomSpeech-How-to-Topics/cognitive-services-custom-speech-create-acoustic-model.md
+++ b/articles/cognitive-services/Custom-Speech-Service/CustomSpeech-How-to-Topics/cognitive-services-custom-speech-create-acoustic-model.md
@@ -89,7 +89,7 @@ ms.locfileid: "49344569"
   speech03.wav  the lazy dog was not amused
 ```
 
-文字記錄會經過文字正規化，以便系統進行處理。 不過，有一些重要的正規化，必須由使用者在將資料上傳到自訂語音服務_之前_完成。 準備您的文字記錄時，請針對適當語言參閱[文字記錄指導方針](cognitive-services-custom-speech-transcription-guidelines.md)上的區段。
+文字記錄會經過文字正規化，以便系統進行處理。 不過，有一些重要的正規化，必須由使用者在將資料上傳到自訂語音服務 _之前_ 完成。 準備您的文字記錄時，請針對適當語言參閱[文字記錄指導方針](cognitive-services-custom-speech-transcription-guidelines.md)上的區段。
 
 使用[自訂語音服務入口網站](https://cris.ai)完成下列步驟。 
 


### PR DESCRIPTION
refs: #245 

@LisandroSu 
You wrote as follows,

```
Hello, @changeworld

Thank you for your feedback and suggestion.

Unfortunately, we do not use italics for Chinese characters which is/are not fully aligned with our criteria for acceptance
```

The current page is as follows.
<img width="780" alt="evi" src="https://user-images.githubusercontent.com/1207985/51426106-17cc1b80-1c29-11e9-841f-d6a67a49d1b8.png">
There is no doubt that the current page is incorrectly displayed (`_` is displayed).

* If you wrote "we do not use italics for Chinese characters which is/are not fully aligned with our criteria for acceptance" is correct
  * the current "不過，有一些重要的正規化，必須由使用者在將資料上傳到自訂語音服務_之前_完成。" is incorrest. So, this must be changed to "不過，有一些重要的正規化，必須由使用者在將資料上傳到自訂語音服務之前完成。".

As I looked at other pages and localization, it seems it looks like italics, so I thought that italic notation of "_之前_" is correct. Therefore, I am sending PR again.

If you close this PR, I will send you a PR that changes to "不過，有一些重要的正規化，必須由使用者在將資料上傳到自訂語音服務之前完成。".